### PR TITLE
Drop stackr

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -28,10 +28,6 @@
     "url": "https://github.com/epiforecasts/scoringutils"
   },
   {
-    "package": "stackr",
-    "url": "https://github.com/epiforecasts/stackr"
-  },
-  {
     "package": "idbrms",
     "url": "https://github.com/epiforecasts/idbrms"
   },


### PR DESCRIPTION
I think `stackr` is dead or at least dead for now. Probably not worth keeping on the universe with a failing build. 