### PR TITLE
Add quantgen package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -84,5 +84,9 @@
     "package": "forecastbaselines",
     "url": "https://github.com/epiforecasts/forecastbaselines",
     "branch": "*release"
+  },
+  {
+    "package": "quantgen",
+    "url": "https://github.com/epiforecasts/quantgen"
   }
 ]


### PR DESCRIPTION
## Summary

- Adds `quantgen` (from `epiforecasts/quantgen` fork) to the r-universe registry
- This is a dependency of `qrensemble` which is already in the registry, but `quantgen` itself was missing, causing CI failures in downstream packages (e.g. nfidd)